### PR TITLE
Add `ratatouille()` a function to fetch invasive species data from RATO in a single call. 

### DIFF
--- a/R/get_objects.R
+++ b/R/get_objects.R
@@ -107,6 +107,16 @@ get_objects <- function(object_ids, token = get_token(), batch_size = 50) {
       # Combine all the data.frames together so we have one row per record
       purrr::list_rbind()
   }
-
-  return(objects_df)
+  
+  # convert datetime fields into POSIXct
+  parsed_df <-
+    objects_df %>%
+    dplyr::mutate(dplyr::across(
+      dplyr::contains("Datum"), # RATO datetime fields have Datum in their name
+      ~ as.POSIXct(.x / 1000, # miliseconds since 1970
+                   origin = "1970-01-01")
+    ))
+  
+  # return the parsed data.frame
+  return(parsed_df)
 }

--- a/R/get_objects.R
+++ b/R/get_objects.R
@@ -16,7 +16,9 @@
 #'
 #' @return tibble of requested objects.
 #' @export
-get_objects <- function(object_ids, token = get_token(), batch_size = 50) {
+get_objects <- function(object_ids = list_object_ids(),
+                        token = get_token(),
+                        batch_size = 50) {
   # Assert that objects were requested
   assertthat::assert_that(assertthat::not_empty(object_ids))
 

--- a/R/ratatouille.R
+++ b/R/ratatouille.R
@@ -1,0 +1,20 @@
+#' Fetch raw invasive species data
+#'
+#'
+#' @param source Character string indicating the source of the data to fetch. By
+#'   default RATO data is fetched.
+#' @param ... Passed on to internal helpers.
+#'
+#' @return A data.frame containing the raw invasive species data.
+#' @export
+#'
+#' @examples
+#' ratatouille()
+ratatouille <- function(source = c("rato"), ...) {
+  raw_data <- 
+    switch (rlang::arg_match(source),
+    rato = get_objects(...)
+  )
+  
+  return(raw_data)
+}

--- a/tests/testthat/test-get_objects.R
+++ b/tests/testthat/test-get_objects.R
@@ -41,3 +41,13 @@ test_that("get_objects() warns for batch sizes above 50", {
 test_that("get_objects() can fallback on dplyr if data.table isn't installed", {
   # Implement with mocked binding or with withr::with_libpath ?
 })
+
+test_that("get_objects() returns POSIXct dates and not miliseconds since 1970",{
+  # fetch 150 random records
+  rato_obs <-
+    get_objects(object_ids = sample(list_object_ids(), size = 150))
+  
+  dplyr::select(rato_obs, dplyr::contains("Datum")) %>% 
+    purrr::walk(expect_s3_class, "POSIXct")
+  
+})

--- a/tests/testthat/test-ratatouille.R
+++ b/tests/testthat/test-ratatouille.R
@@ -1,0 +1,27 @@
+test_that("ratatouille supports fetching data from rato", {
+  skip_if_offline(host = "gis.oost-vlaanderen.be")
+  skip_if(Sys.getenv("RATO_USER") == "")
+  skip_if(Sys.getenv("RATO_PWD") == "")
+
+  expect_s3_class(
+    ratatouille(source = "rato"),
+    "data.frame"
+  )
+})
+
+test_that("ratatouille returns error on invalid source", {
+  expect_error(
+    ratatouille(source = "not a source"),
+    regexp = "`source` must be one of"
+  )
+})
+
+test_that("ratatouille can pass on arguments to it's internal helpers", {
+  my_object_ids <- sample(list_object_ids(), size = 5)
+  
+  expect_s3_class(
+    ratatouille(object_ids = my_object_ids,
+                batch_size = 1),
+    "data.frame"
+  )
+})


### PR DESCRIPTION
This pull request adds a new user-facing function for fetching raw invasive species data and improves the handling of datetime fields in the returned data. It also introduces comprehensive tests to ensure correct behavior and error handling.

**New functionality:**

* Added the `ratatouille` function to provide a simple interface for fetching raw invasive species data, with support for source selection and argument passing to internal helpers.

**Data handling improvements:**

* Updated `get_objects` to automatically convert datetime fields containing "Datum" from milliseconds since 1970 to `POSIXct` objects for easier downstream usage.
* Set the default value of `object_ids` in `get_objects` to `list_object_ids()`, simplifying usage when fetching all objects.

**Testing and validation:**

* Added tests to verify that `get_objects` returns `POSIXct` dates and not raw milliseconds.
* Added tests for the `ratatouille` function to check supported sources, error handling for invalid sources, and argument passing to internal helpers.