### PR TITLE
Add retries for fetching token and listing objects. 

### DIFF
--- a/R/get_token.R
+++ b/R/get_token.R
@@ -48,7 +48,8 @@ get_token <- function(username = Sys.getenv("RATO_USER"),
       referer = "https://gis.oost-vlaanderen.be",
       expiration = getOption("ratatouille.rato_expires_minutes"),
       f = "json"
-    )
+    ) %>% 
+    httr2::req_retry(max_tries = 3)
 
   # Parse the API response
   token_response <-

--- a/R/list_object_ids.R
+++ b/R/list_object_ids.R
@@ -25,7 +25,8 @@ list_object_ids <- function(token = get_token()) {
       returnIdsOnly = "true",
       f = "pjson",
       token = token
-    )
+    ) %>% 
+    httr2::req_retry(max_tries = 3)
   
   # Perform request
   object_ids_response <- 


### PR DESCRIPTION
## AI SUMMARY

This pull request introduces a small but important improvement to the reliability of API requests in the codebase. The main change is the addition of automatic retry logic to two functions, ensuring that transient network errors are handled gracefully.

**API request reliability improvements:**

* Added `httr2::req_retry(max_tries = 3)` to the API request in `get_token` within `R/get_token.R`, so token requests will be retried up to three times if they fail.
* Added `httr2::req_retry(max_tries = 3)` to the API request in `list_object_ids` within `R/list_object_ids.R`, ensuring object ID requests are also retried up to three times.