### PR TITLE
Add option/env var to change RATO API throttling behaviour

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # ratatouille (development version)
 - `magrittr` is no longer a direct dependency, the package now uses base pipes 
 `|>` internally. (#41)
+- The RATO REST API capacity can now be set with an `options()` or by setting 
+the environmental variable `RATO_API_CAPACITY`. (#43)
 # ratatouille 1.0.0
 - Add `ratatouille()`, a function to fetch all available invasive species data 
 from RATO in a single function call. (#36)

--- a/R/get_objects.R
+++ b/R/get_objects.R
@@ -67,7 +67,10 @@ get_objects <- function(object_ids = list_object_ids(),
     }) |>
     # Set capacity of API: handle capacity outstanding requests, then wait for
     # requests to finish
-    purrr::map(~ httr2::req_throttle(.x, capacity = 1000)) |>
+    purrr::map( ~ httr2::req_throttle(.x,
+                                      capacity = getOption(
+                                        "ratatouille.RATO_API_CAPACITY")
+                                      )) |>
     # max_tries needs to be 2 for req_parallel
     purrr::map(~ httr2::req_retry(.x, max_tries = 3))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -36,7 +36,8 @@ as_datetime <- function(miliseconds, origin = "1970-01-01", ...) {
   op <- options()
   op.ratatouille <- list(
     ratatouille.rato_expires_minutes = 5,
-    ratatouille.cache_max_age_secs = 150
+    ratatouille.cache_max_age_secs = 150,
+    ratatouille.RATO_API_CAPACITY = 150
   )
   toset <- !(names(op.ratatouille) %in% names(op))
   if (any(toset)) options(op.ratatouille[toset])


### PR DESCRIPTION
This PR adds a env var (`RATO_API_CAPACITY`) / package option (`ratatouille.RATO_API_CAPACITY`) that can be used to change the throttling behaviour. 

The value determines how many requests can be outstanding before the package starts waiting, setting it to a high value will make fetching objects much quicker as more will be fetched in parallel, setting it to a lower value will make the whole ordeal much more reliable and avoid things like gateway errors or disconnects. 

The default is low, but can be easily set to a higher value. 